### PR TITLE
Prevent node 19 to hang under installation (#5554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+11.0.0-rc.1.1 Release notes (2023-3-24)
+=============================================================
+### Notes
+This is primarily a re-release of `11.0.0-rc.1`, which is compatible with React Native v0.69.0 or above.
+The release is based on Realm JS v10.19.5.
+
+### Enhancements
+* None.
+
+### Fixed
+* Installation will hang when using Node 19. ([#5136](https://github.com/realm/realm-js/issues/5136), since v10.13.0)
+
+### Compatibility
+* React Native equal to or above `v0.69.0` and above, since we're shipping binaries pre-compiled against the JSI ABI.
+* Atlas App Services.
+* Realm Studio v12.0.0.
+* APIs are backwards compatible with all previous releases of Realm JavaScript in the 10.5.x series.
+* File format: generates Realms with format v22 (reads and upgrades file format v5 or later for non-synced Realm, upgrades file format v10 or later for synced Realms).
+
+### Internal
+<!-- * Either mention core version or upgrade -->
+<!-- * Using Realm Core vX.Y.Z -->
+<!-- * Upgraded Realm Core from vX.Y.Z to vA.B.C -->
+
 11.0.0-rc.1 Release notes (2022-7-11)
 =============================================================
 ### Notes

--- a/scripts/submit-analytics.js
+++ b/scripts/submit-analytics.js
@@ -215,31 +215,11 @@ async function collectPlatformData(packagePath = getProjectRoot()) {
 }
 
 /**
- * Send collected analytics data to Realm's servers over HTTPS
- * @param  {Object} payload analytics info
+ * Collect and send analytics data to MongoDB over HTTPS
+ * @param  {boolean} dryRun if true, collect data but don't submit
  */
-async function dispatchAnalytics(payload) {
-  const https = require("https");
-
-  return new Promise((resolve, reject) => {
-    const requestUrl = getAnalyticsRequestUrl(payload);
-
-    https
-      .get(requestUrl, (res) => {
-        resolve({
-          statusCode: res.statusCode,
-          statusMessage: res.statusMessage,
-        });
-      })
-      .on("error", (error) => {
-        const message = error && error.message ? error.message : error;
-        const err = new Error(`Failed to dispatch analytics: ${message}`);
-        reject(err);
-      });
-  });
-}
-
 async function submitAnalytics(dryRun) {
+  const https = require("https");
   const data = await collectPlatformData();
   const payload = {
     webHook: {
@@ -259,7 +239,24 @@ async function submitAnalytics(dryRun) {
     return;
   }
 
-  await Promise.all([dispatchAnalytics(payload)]);
+  return new Promise((resolve, reject) => {
+    // node 19 turns on keep-alive by default and it will make the https.get() to hang
+    // https://github.com/realm/realm-js/issues/5136
+    const requestUrl = getAnalyticsRequestUrl(payload);
+
+    https
+      .get(requestUrl, { agent: new https.Agent({ keepAlive: false }) }, (res) => {
+        resolve({
+          statusCode: res.statusCode,
+          statusMessage: res.statusMessage,
+        });
+      })
+      .on("error", (error) => {
+        const message = error && error.message ? error.message : error;
+        const err = new Error(`Failed to dispatch analytics: ${message}`);
+        reject(err);
+      });
+  });
 }
 
 const optionDefinitions = [


### PR DESCRIPTION
* node 19 changes default behaviour of https.get() so we set it to the old behaviour

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
fix node 19 hang issue for RN 0.69
<!-- E.g. reference to other repos: This closes realm/realm-sync#??? -->
This closes https://github.com/realm/realm-js/issues/5136 and https://github.com/realm/realm-js/issues/5547 for v11.0.0-rc.1

<!-- Please read CONTRIBUTING.md -->

This closes # ??? <!-- link to an existing issue -->

## ☑️ ToDos
<!-- Add your own todos here -->
* [ ] 📝 Changelog entry
* [ ] 📝 `Compatibility` label is updated or copied from previous entry
* [ ] 📝 Update `COMPATIBILITY.md`
* [ ] 🚦 Tests
* [ ] 🔀 Executed flexible sync tests locally if modifying flexible sync
* [ ] 📦 Updated internal package version in consuming `package.json`s (if updating internal packages)
* [ ] 📱 Check the React Native/other sample apps work if necessary
* [ ] 📝 Public documentation PR created or is not necessary
* [ ] 💥 `Breaking` label has been applied or is not necessary

*If this PR adds or changes public API's:*
* [ ] typescript definitions file is updated
* [ ] jsdoc files updated
